### PR TITLE
fix: default to not show legend

### DIFF
--- a/src/object-definition.js
+++ b/src/object-definition.js
@@ -218,7 +218,7 @@ const objectDefinition = () => {
        * @type {boolean}
        * @default
        */
-      show: true,
+      show: false,
       /**
        * Show the legend title.
        * @type {boolean}


### PR DESCRIPTION
To match the old treemap.
(Do we want to keep the old behaviour or should we change it)