### PR TITLE
fix: check for undefined in select prop

### DIFF
--- a/src/__tests__/__snapshots__/picassodef.test.js.snap
+++ b/src/__tests__/__snapshots__/picassodef.test.js.snap
@@ -18,6 +18,7 @@ Object {
             },
             "select": Object {
               "field": "qDimensionInfo/0",
+              "reduce": [Function],
             },
           },
           "value": [Function],

--- a/src/picasso-def/components/labels.js
+++ b/src/picasso-def/components/labels.js
@@ -183,7 +183,7 @@ export const calculateSizes = ({ rect, renderer, text }) => {
   return { fontSize, bounding };
 };
 
-export const createOverlayLabel = ({ node, avgColor, width, height, renderer, getContrastingColorTo, level }) => {
+export const createOverlayLabel = ({ node, avgColor, width, height, renderer, getContrastingColorTo }) => {
   const text = node.data.label;
   const rect = { x: 0, y: 0, width, height };
   const textMeasure = calculateSizes({ rect, renderer, text });
@@ -206,14 +206,11 @@ export const createOverlayLabel = ({ node, avgColor, width, height, renderer, ge
       strokeWidth: 1,
       opacity: 0.7,
       baseline: 'central',
-      data:
-        level < 2
-          ? {
-              ...node.data,
-              depth: node.depth,
-              overlay: true,
-            }
-          : undefined,
+      data: {
+        ...node.data,
+        depth: node.depth,
+        overlay: true,
+      },
     };
   }
   return undefined;

--- a/src/picasso-def/components/labels.js
+++ b/src/picasso-def/components/labels.js
@@ -183,7 +183,7 @@ export const calculateSizes = ({ rect, renderer, text }) => {
   return { fontSize, bounding };
 };
 
-export const createOverlayLabel = ({ node, avgColor, width, height, renderer, getContrastingColorTo }) => {
+export const createOverlayLabel = ({ node, avgColor, width, height, renderer, getContrastingColorTo, level }) => {
   const text = node.data.label;
   const rect = { x: 0, y: 0, width, height };
   const textMeasure = calculateSizes({ rect, renderer, text });
@@ -192,6 +192,7 @@ export const createOverlayLabel = ({ node, avgColor, width, height, renderer, ge
   const y = node.y0 + height / 2;
   const fontHeight = parseInt(fontSize, 10);
   const fill = getContrastingColorTo(avgColor);
+  // only add the data if the current level is less than the overlay level wichi is 2
   if (fontHeight > 8) {
     return {
       type: 'text',
@@ -205,7 +206,14 @@ export const createOverlayLabel = ({ node, avgColor, width, height, renderer, ge
       strokeWidth: 1,
       opacity: 0.7,
       baseline: 'central',
-      data: { ...node.data, depth: node.depth, overlay: true },
+      data:
+        level < 2
+          ? {
+              ...node.data,
+              depth: node.depth,
+              overlay: true,
+            }
+          : undefined,
     };
   }
   return undefined;

--- a/src/picasso-def/components/labels.js
+++ b/src/picasso-def/components/labels.js
@@ -192,7 +192,6 @@ export const createOverlayLabel = ({ node, avgColor, width, height, renderer, ge
   const y = node.y0 + height / 2;
   const fontHeight = parseInt(fontSize, 10);
   const fill = getContrastingColorTo(avgColor);
-  // only add the data if the current level is less than the overlay level wichi is 2
   if (fontHeight > 8) {
     return {
       type: 'text',

--- a/src/picasso-def/components/treemap.js
+++ b/src/picasso-def/components/treemap.js
@@ -275,6 +275,7 @@ export const treemap = () => ({
         height,
         renderer: this.renderer,
         getContrastingColorTo,
+        level,
       });
       if (label) {
         overlayLabels.push(label);

--- a/src/picasso-def/components/treemap.js
+++ b/src/picasso-def/components/treemap.js
@@ -275,7 +275,6 @@ export const treemap = () => ({
         height,
         renderer: this.renderer,
         getContrastingColorTo,
-        level,
       });
       if (label) {
         overlayLabels.push(label);

--- a/src/picasso-def/picassoDef.js
+++ b/src/picasso-def/picassoDef.js
@@ -120,7 +120,10 @@ export const picassoDef = ({
           },
           props: {
             color: { field },
-            select: { field: `qDimensionInfo/${selectLevel}` },
+            select: {
+              field: `qDimensionInfo/${selectLevel}`,
+              reduce: (values) => (values.length === 1 ? values[0] : undefined),
+            },
             expressionColor,
             expressionColorText,
             isOther: { value: (d, node) => node.data.qElemNo === -3 },


### PR DESCRIPTION
To reproduce;
1. open Demo App - Beginner's tutorial
2. drill down to fruit
3. select any rectangle where the word Fruit is overlapping

Result: multiple selections were made
Expected: only the selected rectangle

Attached is the expected result
<img width="552" alt="Screen Shot 2022-10-02 at 8 46 51 AM" src="https://user-images.githubusercontent.com/42212158/193454989-5d7b66d9-19eb-4cef-9f33-853f0d5e3f18.png">
