### PR TITLE
chore: make update-snapshot workflow trigger a new verify on commit

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -10,6 +10,8 @@ jobs:
     if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - uses: ./.github/actions/yarn_install
       - run: yarn build
       - run: yarn playwright install --with-deps


### PR DESCRIPTION
see: https://github.com/marketplace/actions/git-auto-commit#commits-made-by-this-action-do-not-trigger-new-workflow-runs